### PR TITLE
Many random things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,17 @@ build:
 	docker run --rm -it \
 		-u `id -u ${USER}`:`id -g ${USER}` \
 		--mount type=bind,source=`pwd`,target=/src \
+		rattboi/naomi-build:latest \
+		make -f Makefile.proj ${TARGET}
+
+.PHONY: menu
+menu:
+	docker run --rm -it \
+		-u `id -u ${USER}`:`id -g ${USER}` \
+		--mount type=bind,source=`pwd`,target=/src \
 		--mount type=bind,source=${GAMES},target=/games \
 		rattboi/naomi-build:latest \
-		make -f Makefile.proj makemenu ${TARGET}
+		make -f Makefile.proj menu
 
 .PHONY: clean
 clean:

--- a/Makefile.proj
+++ b/Makefile.proj
@@ -16,10 +16,10 @@ GAMES = /games
 
 # Provide the top-level ROM creation target for this binary.
 # See scripts.makerom for details about what is customizable.
-all: makemenu a_menu.bin
+all: menu a_menu.bin
 
-.PHONY: makemenu
-makemenu:
+.PHONY: menu
+menu:
 	python3 -m scripts.menugen $(GAMES) > menudata.bin
 
 a_menu.bin: build/naomi.bin menudata.bin

--- a/main.c
+++ b/main.c
@@ -10,13 +10,63 @@ char *console_base = 0;
 unsigned int console_loc = 0;
 #define console_printf(...) do { sprintf(console_base + console_loc, __VA_ARGS__); console_loc += strlen(console_base + console_loc); } while(0)
 
-extern uint8_t __z80_fw_1_bin_data[8184];
+// Byte-swap strings to be 32-bit endian swapped
+// Maple payloads apparently are only 32-bit little-endian
+int convert_to_dma(char* input, char** payload) {
+  int input_len = strlen(input); 
+  //make sure buffer has enough room to hold string + be able to endian-swap the last chunk
+  int buf_size = ((input_len + 1 + 3) & ~0x03); 
 
-void display()
+  *payload = malloc(buf_size);
+  strcpy(*payload, input);
+  for(int i = 0; i < buf_size; i+=4) {
+    char c = (*payload)[i+0];
+    (*payload)[i+0] = (*payload)[i+3];
+    (*payload)[i+3] = c;
+
+    char d = (*payload)[i+1];
+    (*payload)[i+1] = (*payload)[i+2];
+    (*payload)[i+2] = d;
+  }
+
+  return buf_size;
+}
+
+void send_serial(char* text) {
+  uint32_t *resp;
+  char* dma_string;
+
+  int dma_len = convert_to_dma(text, &dma_string);
+
+  resp = maple_swap_data(1, 0, 0xA0, dma_len/4, dma_string);
+  console_printf("Maple Device 1 SendString resp: ");
+  for (int i = 0; i < 10; i++) {
+      console_printf("%02X ", resp[i]);
+  }
+  console_printf("\n");
+  free(dma_string);
+}
+
+int get_buttons(jvs_buttons_t* buttons) {
+  int button_pushed = 0;
+  static jvs_buttons_t last_buttons;
+  *buttons = maple_request_jvs_buttons(0x01, 2);
+
+  if (memcmp(buttons, &last_buttons, sizeof(last_buttons)) != 0) {
+    button_pushed = 1;
+  }
+
+  last_buttons = *buttons;
+  return button_pushed;
+}
+
+
+void display(int y_line)
 {
     // Render a simple test console.
     video_fill_screen(rgb(48, 48, 48));
     video_draw_text(0, 0, rgb(255, 255, 255), console_base);
+    video_fill_box(300,(y_line*8),339,((y_line+1)*8)-1,rgb(255, 0, 0));
     video_wait_for_vblank();
     video_display();
 }
@@ -26,7 +76,9 @@ void main()
     #define MENU_SECTION 0xC030000
     volatile unsigned char *menu_section = (volatile unsigned char *)MENU_SECTION;
 
-    *(menu_section+2000)='\0'; // add null
+    char* end_of_data = strchr((const char *)menu_section,'^'); // special signifier of end of data
+    *end_of_data='\0'; //replace with null. Now we're a string
+
     uint32_t *resp;
 
     // Set up a crude console
@@ -35,63 +87,9 @@ void main()
     console_base = malloc(((640 * 480) / (8 * 8)) + 1);
     memset(console_base, 0, ((640 * 480) / (8 * 8)) + 1);
 
-    // Confirm that this is in fact a new build
-    console_printf("RATTBOI WAS HERE\n");
-    console_printf("From menu section:\n");
     console_printf("%s\n", menu_section);
 
-    
-    // Now, report on the memory test.
-    int self_test = maple_request_self_test();
-    if(self_test == 1)
-    {
-        console_printf("MIE reports healthy!\n");
-    }
-    else
-    {
-        console_printf("MIE reports bad: %d\n", self_test);
-    }
-    display();
-
-    /*
-    maple_request_reset();
-    maple_wait_for_ready();
-
-    uint8_t checksum;
-
-    int update_success = maple_request_update(__z80_fw_1_bin_data, 8184, &checksum);
-    if(update_success != 0) {
-        console_printf("MIE FW Update failed: %d\n", update_success);
-        console_printf("MIE FW Update failed checksum: %d\n", checksum);
-    } else {
-        console_printf("MIE FW Update success!\n");
-    }
-    display();
-    maple_wait_for_ready();
-    */
-
-    // Request version, make sure we're running our updated code.
-    char version[128];
-    maple_request_version(version);
-    console_printf("MIE version string: %s\n", version);
-    display();
-    
-    maple_request_jvs_reset(0x01);
-    maple_wait_for_ready();
-
-    // Now, display the JVS IO version ID.
-    int jvs_id_status = maple_request_jvs_id(0x01, version);
-    if (jvs_id_status == 0) 
-      console_printf("JVS IO ID: %s\n\n", version);
-    else
-      console_printf("JVS IO ID error: %d\n\n", jvs_id_status);
-    display();
-
-
-    uint32_t get_condition_payload = 1;
-
     // Now, read the controls forever.
-    unsigned int reset_loc = console_loc;
     int liveness = 0;
 
     resp = maple_swap_data(1, 0, MAPLE_DEVICE_INFO_REQUEST, 0, NULL);
@@ -108,36 +106,42 @@ void main()
     }
     console_printf("\n");
 
+    jvs_buttons_t buttons;
+    int y_line = 0;
+
+    unsigned int reset_loc = console_loc;
     while ( 1 )
     {
         console_loc = reset_loc;
         console_printf("Liveness indicator: %d\n", liveness++);
 
-        resp = maple_swap_data(1, 0, 0x09, 1, &get_condition_payload);
-        console_printf("Maple Device 1 GetCond resp: ");
-        for (int i = 0; i < 10; i++) {
-            console_printf("%02X ", resp[i]);
+        send_serial("Hello, World!");
+
+        if (get_buttons(&buttons)) {
+          console_printf("\n1P buttons: ");
+          if(buttons.player1.start)
+          {
+              console_printf("start ");
+          }
+          if(buttons.player1.up)
+          {
+              console_printf("up ");
+              if (y_line > 0)
+                y_line--;
+          }
+          if(buttons.player1.down)
+          {
+              console_printf("down ");
+              if(y_line < 40)
+                y_line++;
+          }
+          if(buttons.player1.button1)
+          {
+              console_printf("b1 ");
+          }
         }
-        console_printf("\n");
 
-        resp = maple_swap_data(2, 0, 0x09, 1, &get_condition_payload);
-        console_printf("Maple Device 2 GetCond resp: ");
-        for (int i = 0; i < 10; i++) {
-            console_printf("%02X ", resp[i]);
-        }
-        console_printf("\n");
-
-        //char* hello = "hello there, world";
-        char* hello = "llehht o,ererow !!dl";
-
-        resp = maple_swap_data(1, 0, 0xA0, strlen(hello), hello);
-        console_printf("Maple Device 1 SendString resp: ");
-        for (int i = 0; i < 10; i++) {
-            console_printf("%02X ", resp[i]);
-        }
-        console_printf("\n");
-
-        display();
+        display(y_line);
     }
 }
 
@@ -152,13 +156,3 @@ void test()
 
     while ( 1 ) { ; }
 }
-
-/**
- * Request the MIE upload a new binary and then execute it.
- *
- * Return 0 on success
- *        -1 on unexpected packet received
- *        -2 on bad memory written
- *        -3 on bad crc
- *        -4 on failure to boot code.
- */

--- a/scripts/menugen.py
+++ b/scripts/menugen.py
@@ -4,6 +4,7 @@ import sys
 import glob
 from typing import Dict
 
+# Hack to add the libnaomi scripts to the python system path
 sys.path.append(r'/opt/toolchains/naomi')
 
 from naomi import NaomiRom
@@ -34,6 +35,7 @@ def main() -> int:
         naomi = NaomiRom(data)
         if naomi.valid:
             print(f"{naomi.names[NaomiRom.REGION_JAPAN].strip('- '):>32} - ({naomi.date}) - [{naomi.publisher}]")
+    print("^")
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
* `make menu` is a separate target in the docker Makefile to generate
  the menu metadata
* Fix the menu generator to put an EOF tag at the end of content
    - please note that this is garbage and will be thrown away later
* Make a byte-swapping routine for sending strings over maple-serial in
  the "right order" since DMA stuff seems to be 32-bit only.
* Break out a few things into basic functions (probably should move to
  their own files later)
* Put a dumb little pseudo-cursor on the screen, which can be moved
  up/down. Basic game selector for testing.